### PR TITLE
feat(nodes, modal, storage): Add output nodes, modification modal and save functionality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,20 @@
 import {ReactFlowProvider} from 'reactflow'
 import FlowPanel from './components/reactFlow/FlowPanel'
+import useStore from './store/store';
+import { useEffect } from 'react';
+
 const App = () => {
+  useEffect(() => {
+    const storedNodes = localStorage.getItem('nodes');
+    const storedEdges = localStorage.getItem('edges');
+
+    if (storedNodes && storedEdges) {
+      useStore.setState({
+        nodes: JSON.parse(storedNodes),
+        edges: JSON.parse(storedEdges),
+      });
+    }
+  }, []);
   return (
     <>
     <div className='bg-[#1c1d1f]'>

--- a/src/components/modals/InputModal.tsx
+++ b/src/components/modals/InputModal.tsx
@@ -182,9 +182,10 @@ const InputModal = () => {
             className='bg-[#353535] text-white text-sm focus:outline-none focus:border-b border-[#6f62e8] rounded-md h-6'
             onChange={(evt) => setNodeState({ ...nodeState, trigger: evt.target.value })}
           >
-            <option value='text'>CRM</option>
-            <option value='text'>ALM</option>
-            <option value='text'>ATS</option>
+            <option value="">Select type of trigger</option>
+            <option value='CRM'>CRM</option>
+            <option value='ALM'>ALM</option>
+            <option value='ATS'>ATS</option>
           </select>
         </div>
         <div className='overflow-auto px-6 flex flex-col gap-3'>

--- a/src/components/modals/OutputModal.tsx
+++ b/src/components/modals/OutputModal.tsx
@@ -3,32 +3,23 @@ import useStore from "../../store/store";
 import { useEffect, useState } from "react";
 import { Node } from "reactflow";
 import Modal from "./Modal";
-import { MdDelete } from 'react-icons/md'
-import useDefaultModal from "../../hooks/useDefaultModal";
-
-interface NodeVariable {
-  name: string;
-  value: string;
-  type: string;
-}
+import useOutputModal from '../../hooks/useOutputModal';
 
 interface NodeState {
   label: string;
   background: string | number;
   hidden: boolean;
-  variables: NodeVariable[];
   description: string;
 }
-const DefaultModal = () => {
+const OutputModal = () => {
   const { selectedNode, updateNode, getPropsOfParentNodes } = useStore()
-  const defaultModal = useDefaultModal();
+  const outputModal = useOutputModal();
   const { handleSubmit, reset } = useForm();
 
   const initialNodeState: NodeState = {
     label: selectedNode?.data.label || '',
     background: selectedNode?.style?.background || '#27282c',
     hidden: selectedNode?.hidden || false,
-    variables: selectedNode?.data.variables || [],
     description: selectedNode?.data.description || '',
   };
 
@@ -41,7 +32,6 @@ const DefaultModal = () => {
         data: {
           ...selectedNode.data,
           label: nodeState.label,
-          variables: nodeState.variables,
           description: nodeState.description,
         },
         style: {
@@ -54,66 +44,12 @@ const DefaultModal = () => {
     }
   });
 
-  const handleAddVariable = () => {
-    const nextVariableIndex = nodeState.variables.length + 1;
-    const newVariable = {
-      name: `Variable ${nextVariableIndex}`,
-      value: '',
-    };
-
-    setNodeState((prevState) => ({
-      ...prevState,
-      variables: [...prevState.variables, newVariable],
-    }));
-  };
-
-  const handleVariableChange = (index: number, value: string) => {
-    const updatedVariables = [...nodeState.variables];
-    updatedVariables[index].value = value;
-    setNodeState((prevState) => ({
-      ...prevState,
-      variables: updatedVariables,
-    }));
-  };
-
-  const handleVariableNameChange = (index: number, newName: string) => {
-    const updatedVariables = [...nodeState.variables];
-    updatedVariables[index].name = newName;
-    setNodeState((prevState) => ({
-      ...prevState,
-      variables: updatedVariables,
-    }));
-  };
-
-  const handleRemoveVariable = (index: number) => {
-    const updatedVariables = [...nodeState.variables];
-    updatedVariables.splice(index, 1);
-    setNodeState((prevState) => ({
-      ...prevState,
-      variables: updatedVariables,
-    }));
-  };
-
   const onChange = (open: boolean) => {
     if (!open) {
       reset();
-      defaultModal.onClose();
+      outputModal.onClose();
     }
   };
-
-  const handleVariableTypeChange = (index: number, newType) => {
-    // Aquí puedes manejar el cambio de tipo de variable y ajustar los datos en consecuencia
-    const updatedVariables = [...nodeState.variables];
-    updatedVariables[index].type = newType;
-    // Ajustar el valor de la variable según el nuevo tipo si es necesario
-    if (newType === 'number') {
-      updatedVariables[index].value = parseFloat(updatedVariables[index].value) | 0;
-    } else if (newType === 'boolean') {
-      updatedVariables[index].value = updatedVariables[index].value === 'true';
-    }
-    setNodeState({ ...nodeState, variables: updatedVariables });
-  };
-
 
   const parentNodesVariables = getPropsOfParentNodes(selectedNode?.id);
 
@@ -122,7 +58,6 @@ const DefaultModal = () => {
       label: selectedNode?.data.label || '',
       background: selectedNode?.style?.background || '#27282c',
       hidden: selectedNode?.hidden || false,
-      variables: selectedNode?.data.variables || [],
       description: selectedNode?.data.description || '',
     };
     setNodeState(updatedNodeState);
@@ -132,7 +67,7 @@ const DefaultModal = () => {
     <Modal
       title='Properties'
       description={`Edit Node Properties ${selectedNode?.data.label}`}
-      isOpen={defaultModal.isOpen}
+      isOpen={outputModal.isOpen}
       onChange={onChange}
     >
       <form onSubmit={handleUpdateClick} className='flex flex-col w-[450px] max-h-[600px] h-auto'>
@@ -166,39 +101,6 @@ const DefaultModal = () => {
           </label>
           <textarea className='bg-[#353535] text-white text-sm focus:outline-none focus:border-b border-[#6f62e8] w-full max-h-32 h-28 rounded-md' name="descriptionNode" onChange={(evt) => setNodeState({ ...nodeState, description: evt.target.value })} placeholder={selectedNode?.data['description']}></textarea>
         </div>
-        <div className='overflow-auto px-6 flex flex-col gap-3'>
-          <h2 className='text-sm font-semibold text-white'>Variables</h2>
-          {nodeState.variables.map((variable, index) => (
-            <div key={index} className='flex gap-1 border border-green-400'>
-              <select
-                className='bg-[#353535] text-white text-sm focus:outline-none focus:border-b border-[#6f62e8] rounded-md h-6'
-                onChange={(evt) => handleVariableTypeChange(index, evt.target.value)}
-              >
-                <option value='text'>Text</option>
-                <option value='number'>Number</option>
-                <option value='boolean'>Boolean</option>
-              </select>
-              <input
-                className='bg-[#353535] text-white text-sm focus:outline-none focus:border-b border-[#6f62e8] rounded-md h-6'
-                placeholder={variable.name}
-                onChange={(evt) => handleVariableNameChange(index, evt.target.value)}
-              />
-              :
-              <input
-                className='bg-[#353535] text-white text-sm focus:outline-none focus:border-b border-[#6f62e8] rounded-md h-6'
-                placeholder={variable.value}
-                onChange={(evt) => handleVariableChange(index, evt.target.value)}
-              />
-              <button
-                className='text-red-600  rounded-xl text-xl border border-blue-500 m-0'
-                onClick={() => handleRemoveVariable(index)}
-              >
-                <MdDelete />
-              </button>
-            </div>
-          ))}
-
-        </div>
         {parentNodesVariables.length > 0 && (
           <div className='px-6 text-white overflow-auto max-h-[250px] py-3'>
             <h2 className='text-sm font-semibold'>Parent Node Variables</h2>
@@ -216,7 +118,6 @@ const DefaultModal = () => {
           </div>
         )}
         <div className='flex flex-col gap-2 py-2'>
-          <button className='text-white bg-[#6f62e8] rounded-xl w-36 m-auto' onClick={handleAddVariable}>Add Variable</button>
           <button className='text-white bg-[#6f62e8] rounded-xl w-36 m-auto'>Update Node</button>
         </div>
       </form>
@@ -224,4 +125,4 @@ const DefaultModal = () => {
   )
 }
 
-export default DefaultModal
+export default OutputModal

--- a/src/components/reactFlow/FlowPanel.tsx
+++ b/src/components/reactFlow/FlowPanel.tsx
@@ -7,11 +7,14 @@ import { useCallback, useRef, useState } from 'react';
 import PanelTypes from '../panels/PanelTypes';
 import InputModal from '../modals/InputModal';
 import DefaultNode from './Nodes/DefaultNode';
-import DefaultModal from '../modals/defaultModal';
+import DefaultModal from '../modals/DefaultModal';
+import OutputNode from './Nodes/OutputNode';
+import OutputModal from '../modals/OutputModal';
 
 const nodeTypes: NodeTypes = {
   inputNode: InputNode,
-  defaultNode: DefaultNode
+  defaultNode: DefaultNode,
+  outputNode: OutputNode
 }
 
 let id = 0;
@@ -128,6 +131,7 @@ const FlowPanel = () => {
         </div>
         <InputModal />
         <DefaultModal />
+        <OutputModal />
       </div>
     </div>
   )

--- a/src/components/reactFlow/Nodes/OutputNode.tsx
+++ b/src/components/reactFlow/Nodes/OutputNode.tsx
@@ -1,0 +1,41 @@
+import { FunctionComponent, memo } from 'react';
+import { Handle, NodeProps, Position } from 'reactflow';
+import useOutputModal from '../../../hooks/useOutputModal';
+
+const OutputNode: FunctionComponent<NodeProps> = memo(({ data, isConnectable }) => {
+  const outputModal = useOutputModal();
+
+  const openOutputModal = () => {
+    outputModal.onOpen();
+  }
+
+  const handleDoubleClick = () => {
+    openOutputModal()
+  }
+  return (
+    <>
+    <Handle
+        type="target"
+        position={Position.Top}
+        onConnect={(params) => console.log('handle onConnect', params)}
+        isConnectable={isConnectable}
+      />
+      <div
+        className='rounded-md text-xs text-center text-white'
+        onDoubleClick={handleDoubleClick}
+      >
+        <h1 className='text-center text-base py-3 px-6 font-bold flex items-center gap-3'>
+          {data?.label}
+        </h1>
+        {data?.description.length !== 0 ? (
+          <div className='border-t border-gray-600 px-3'>
+            <h2>Description:</h2>
+            <p className='max-w-[120px] break-words'>{data?.description}</p>
+          </div>
+        ) : null}
+      </div>
+    </>
+  )
+})
+
+export default OutputNode;

--- a/src/hooks/useOutputModal.tsx
+++ b/src/hooks/useOutputModal.tsx
@@ -1,0 +1,16 @@
+import { create } from "zustand";
+
+interface OutputModalStore {
+  isOpen: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+}
+
+
+const useOutputModal = create<OutputModalStore>((set) => ({
+  isOpen: false,
+  onOpen: () => set({ isOpen: true }),
+  onClose: () => set({ isOpen: false })
+}))
+
+export default useOutputModal

--- a/src/store/nodes.ts
+++ b/src/store/nodes.ts
@@ -1,3 +1,15 @@
 import { Node } from "reactflow";
 
-export default [] as Node[];
+export default [
+  {
+    id: 'Node_init',
+    type: 'inputNode',
+    data: { label: 'Node_1', trigger: 'CRM', variables: [], description: '' },
+    position: { x: 250, y: 25 },
+    style: {
+      background: '#27282c',
+      borderRadius: '6px',
+      border: 'solid 1px #6f62e8',
+    },
+  },
+] as Node[];

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -39,11 +39,13 @@ const useStore = createWithEqualityFn<RFState>((set, get) => ({
     set({
       nodes: applyNodeChanges(changes, get().nodes),
     });
+    localStorage.setItem('nodes', JSON.stringify(get().nodes));
   },
   onEdgesChange: (changes: EdgeChange[]) => {
     set({
       edges: applyEdgeChanges(changes, get().edges),
     });
+    
   },
   onConnect: (connection: Connection) => {
     const newEdge = {
@@ -53,6 +55,7 @@ const useStore = createWithEqualityFn<RFState>((set, get) => ({
     set({
       edges: addEdge(newEdge, get().edges),
     });
+    localStorage.setItem('edges', JSON.stringify(get().edges));
   },
   addNode: (newNode: Node) => {
     set((state) => ({


### PR DESCRIPTION
In this commit, output nodes have been added to the application, expanding the node options available. A modal has also been implemented that allows users to modify the properties of these nodes. In addition, the functionality to save both edges and nodes to storage has been added, allowing the state of the application to be preserved between sessions.